### PR TITLE
Look for settings in the environment if they don't exist in the settings file

### DIFF
--- a/commonconf/backend/parser.py
+++ b/commonconf/backend/parser.py
@@ -1,6 +1,7 @@
 # Copyright 2021 UW-IT, University of Washington
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from configparser import RawConfigParser, NoOptionError
 
 
@@ -14,5 +15,9 @@ class ConfigParserBackend(object):
         try:
             return self.config.get(self.section, key)
         except NoOptionError as ex:
-            raise AttributeError(
-                "Key {} not in section {}".format(key, self.section))
+            try:
+                return os.environ[key]
+            except KeyError:
+                raise AttributeError(
+                    "Key {} not in section {} or in environment variables"
+                    .format(key, self.section))

--- a/commonconf/tests/test_configparser.py
+++ b/commonconf/tests/test_configparser.py
@@ -28,3 +28,10 @@ class TestConfigParserBackend(unittest.TestCase):
 
         value = getattr(settings, "MISSING_KEY_FOR_TESTING", "OK")
         self.assertEquals(value, "OK")
+
+    def test_environment_value(self):
+        use_configparser_backend(config_path, "Section1")
+
+        os.environ["MISSING_KEY_FROM_SETTINGS"] = "MISSING_KEY_VALUE"
+        self.assertEquals(settings.MISSING_KEY_FROM_SETTINGS,
+                          "MISSING_KEY_VALUE")


### PR DESCRIPTION
In Kubernetes deployments it is a common practice that secrets defined in the Helm Chart get read into environment variables upon deployment. In Django it this is a non issue because the Django settings.py file is an executable python file that makes it easy to dynamically assign environment variables to python variables. With the commonconf yaml files, we encounter the problem that yaml files are not executable and therefore there is no easy way to dynamically add settings at runtime. This contribution is a remedy to that problem. With this change, if a setting is not found in the commonconf backend settings file it is automatically attempted to be looked up in the system environment variables.